### PR TITLE
Change sortkey logic

### DIFF
--- a/src/Comets.Core/Core/Comet.cs
+++ b/src/Comets.Core/Core/Comet.cs
@@ -31,8 +31,7 @@ namespace Comets.Core
 		private double _a;
 		private double _Q;
 		private double _n;
-		private double _sortkey;
-		private string _idKey;
+		private string _sortkey;
 
 		private Ephemeris _epPerihelion;
 		private Ephemeris _epCurrent;
@@ -235,19 +234,10 @@ namespace Comets.Core
 		/// <summary>
 		/// Sortkey
 		/// </summary>
-		public double sortkey
+		public string sortkey
 		{
 			get { return _sortkey; }
 			set { _sortkey = value; }
-		}
-
-		/// <summary>
-		/// IdKey
-		/// </summary>
-		public string idKey
-		{
-			get { return _idKey; }
-			set { _idKey = value; }
 		}
 
 		private Ephemeris PerihelionEphemeris

--- a/src/Comets.Core/Managers/CometManager.cs
+++ b/src/Comets.Core/Managers/CometManager.cs
@@ -196,24 +196,53 @@ namespace Comets.Core.Managers
 		/// </summary>
 		/// <param name="id">ID</param>
 		/// <returns></returns>
-		public static string GetIdKey(string id)
+		public static string GetIdKey(string id, string fragment = "")
 		{
-			// todo, remove?
-
 			string key = String.Empty;
 
-			if (Char.IsDigit(id[0]))
-			{
-				key = id;
+			string per = "0001"; // periodic:     1P
+			string neg = "0010"; // negative year C/-YYYY
+			string pos = "0100"; // positive year C/YYYY
+			string ins = "1000"; // interstellar: 1I
 
-				for (int i = key.Length; i < 5; i++)
-					key = '0' + key;
+			if (Char.IsDigit(id[0])) // 1P
+				key = id.EndsWith("I") ? ins : per;
+			else
+				key = id[2] == '-' ? neg : pos;
+
+			string number;
+			string codeL = "0000";
+			string codeD = "0000";
+
+			if (Char.IsDigit(id[0])) // 1P
+			{
+				number = id.Substring(0, id.Length - 1).PadLeft(5, '0');
 			}
 			else
 			{
-				key = id.Remove(0, 2).Replace("-", String.Empty).Replace(" ", String.Empty);
+				string[] yc = id.Split(' ');
+				int year = yc[0].Split('/')[1].Int();
+
+				year += 10000;
+				number = year.ToString().PadLeft(5, '0');
+
+				string code = yc[1];
+				Match m1 = _regAlphaNum.Match(code);
+				codeL = m1.Groups["letters"].Value.PadLeft(4, '0');
+				codeD = m1.Groups["digits"].Value.PadLeft(4, '0');
 			}
 
+			string fragmLetters = "0000";
+			string fragmDigits = "00";
+
+			if (fragment != String.Empty)
+			{
+				Match m2 = _regAlphaNum.Match(fragment);
+				fragmLetters = m2.Groups["letters"].Value.PadLeft(4, '0');
+				fragmDigits = m2.Groups["digits"].Value.PadLeft(2, '0'); ;
+			}
+
+			key = $"{key}{number}{codeL}{codeD}{fragmLetters}{fragmDigits}";
 			return key;
 		}
 

--- a/src/Comets.Core/Managers/CometManager.cs
+++ b/src/Comets.Core/Managers/CometManager.cs
@@ -168,17 +168,30 @@ namespace Comets.Core.Managers
 				codeD = m1.Groups["digits"].Value.PadLeft(3, '0');
 			}
 
-			string fragmLetters = "00";
-			string fragmDigits = "00";
+			string fragL = "00";
+			string fragD = "00";
 
 			if (fragment != String.Empty)
 			{
 				Match m2 = _regAlphaNum.Match(fragment);
-				fragmLetters = m2.Groups["letters"].Value.PadLeft(2, '0');
-				fragmDigits = m2.Groups["digits"].Value.PadLeft(2, '0'); ;
+				fragL = m2.Groups["letters"].Value.PadLeft(2, '0');
+				fragD = m2.Groups["digits"].Value.PadLeft(2, '0'); ;
 			}
 
-			key = $"{key}{number}{codeL}{codeD}{fragmLetters}{fragmDigits}";
+			/*===================================
+			some examples, expanded for clarity
+			1P            >  0 0001 000 000 00 00  ; numbered periodic comets with leading '0'
+			3D-A          >  0 0003 000 000 0A 00
+			5D-B1         >  0 0005 000 000 0B 01
+			240P          >  0 0240 000 000 00 00
+			C/-146 P1     >  1 9854 00P 001 00 00  ; negative years with leading '1'
+			C/-43 K1      >  1 9957 00K 001 00 00
+			C/240 V1      >  2 0240 00V 001 00 00  ; positive years with leading '2'; not the same as 240 above
+			C/2000 A1-B2  >  2 2000 00A 001 0B 02
+			1I            >  3 0001 000 000 00 00  ; interstellar objects moved to the end with leading '3'
+			===================================*/
+
+			key = $"{key}{number}{codeL}{codeD}{fragL}{fragD}";
 			return key;
 		}
 

--- a/src/Comets.Core/Managers/CometManager.cs
+++ b/src/Comets.Core/Managers/CometManager.cs
@@ -134,10 +134,10 @@ namespace Comets.Core.Managers
 		{
 			string key = String.Empty;
 
-			string per = "0001"; // periodic:     1P
-			string neg = "0010"; // negative year C/-YYYY
-			string pos = "0100"; // positive year C/YYYY
-			string ins = "1000"; // interstellar: 1I
+			string per = "0"; // periodic:     1P
+			string neg = "1"; // negative year C/-YYYY
+			string pos = "2"; // positive year C/YYYY
+			string ins = "3"; // interstellar: 1I
 
 			if (Char.IsDigit(id[0])) // 1P
 				key = id.EndsWith("I") ? ins : per;
@@ -145,34 +145,36 @@ namespace Comets.Core.Managers
 				key = id[2] == '-' ? neg : pos;
 
 			string number;
-			string codeL = "0000";
-			string codeD = "0000";
+			string codeL = "000";
+			string codeD = "000";
 
 			if (Char.IsDigit(id[0])) // 1P
 			{
-				number = id.Substring(0, id.Length - 1).PadLeft(5, '0');
+				number = id.Substring(0, id.Length - 1).PadLeft(4, '0');
 			}
 			else
 			{
 				string[] yc = id.Split(' ');
 				int year = yc[0].Split('/')[1].Int();
 
-				year += 10000;
-				number = year.ToString().PadLeft(5, '0');
+				if (year < 0)
+					year += 10000;
+
+				number = year.ToString().PadLeft(4, '0');
 
 				string code = yc[1];
 				Match m1 = _regAlphaNum.Match(code);
-				codeL = m1.Groups["letters"].Value.PadLeft(4, '0');
-				codeD = m1.Groups["digits"].Value.PadLeft(4, '0');
+				codeL = m1.Groups["letters"].Value.PadLeft(3, '0');
+				codeD = m1.Groups["digits"].Value.PadLeft(3, '0');
 			}
 
-			string fragmLetters = "0000";
+			string fragmLetters = "00";
 			string fragmDigits = "00";
 
 			if (fragment != String.Empty)
 			{
 				Match m2 = _regAlphaNum.Match(fragment);
-				fragmLetters = m2.Groups["letters"].Value.PadLeft(4, '0');
+				fragmLetters = m2.Groups["letters"].Value.PadLeft(2, '0');
 				fragmDigits = m2.Groups["digits"].Value.PadLeft(2, '0'); ;
 			}
 

--- a/src/Comets.Core/Managers/CometManager.cs
+++ b/src/Comets.Core/Managers/CometManager.cs
@@ -130,73 +130,7 @@ namespace Comets.Core.Managers
 		/// <summary>
 		/// Calculates Sortkey
 		/// </summary>
-		/// <param name="id">ID</param>
-		/// <returns></returns>
-		public static double GetSortkey(string id, string fragment)
-		{
-			double sort = 0.0;
-			double v = 0.0;
-			double cOffset = 10000.0; // not per.
-			double iOffset = 100000.0; // interst.
-
-			if (fragment != String.Empty)
-			{
-				Match match = _regAlphaNum.Match(fragment);
-				string fragmLetters = match.Groups["letters"].Value;
-				string fragmDigits = match.Groups["digits"].Value;
-
-				for (int i = 0, divider = 1000000000; i < fragmLetters.Length; i++, divider *= 100)
-					v += (fragmLetters[i] - 64) / (double)divider;
-
-				if (fragmDigits != String.Empty)
-					v += fragmDigits.Double() / 10000000000000.0;
-			}
-
-			if (Char.IsDigit(id[0]))
-			{
-				// 1P, 2I...
-				sort = id.Substring(0, id.Length - 1).Double();
-
-				if (id.EndsWith("I"))
-					sort += iOffset;
-			}
-			else
-			{
-				string[] yc = id.Split(' ');
-				sort = yc[0].Split('/')[1].Double() + cOffset; //da npr C/240 V1 ne bude isto kao i 240P/NEAT i slicno...
-
-				string code = yc[1];
-				Match match = _regAlphaNum.Match(code);
-				string codeLetters = match.Groups["letters"].Value;
-				string codeDigits = match.Groups["digits"].Value;
-
-				// pretpostavka da mogu doci najvise 2 slova u id-u
-				// 1. slovo dijelim sa 100
-				// 2. slovo dijelim sa 10000
-				// broj dijelim sa 10000000; pretpostavka da se moze pojaviti najvise troznamenkasti broj
-
-				for (int i = 0, divider = 100; i < codeLetters.Length; i++, divider *= 100)
-					v += (codeLetters[i] - 64) / (double)divider;
-
-				if (codeDigits != String.Empty)
-					v += codeDigits.Double() / 10000000.0;
-			}
-
-			sort += v;
-
-			return sort;
-		}
-
-		#endregion
-
-		#region GetIdKey
-
-		/// <summary>
-		/// Returns IDKey
-		/// </summary>
-		/// <param name="id">ID</param>
-		/// <returns></returns>
-		public static string GetIdKey(string id, string fragment = "")
+		public static string GetSortkey(string id, string fragment)
 		{
 			string key = String.Empty;
 

--- a/src/Comets.Core/Managers/ImportManager.cs
+++ b/src/Comets.Core/Managers/ImportManager.cs
@@ -417,7 +417,7 @@ namespace Comets.Core.Managers
 			c.Q = CometManager.GetAphelionDistance(c.e, c.a);
 
 			c.sortkey = CometManager.GetSortkey(c.id, c.fragment);
-			c.idKey = CometManager.GetIdKey(c.id);
+			c.idKey = CometManager.GetIdKey(c.id, c.fragment);
 
 			return c;
 		}

--- a/src/Comets.Core/Managers/ImportManager.cs
+++ b/src/Comets.Core/Managers/ImportManager.cs
@@ -417,7 +417,6 @@ namespace Comets.Core.Managers
 			c.Q = CometManager.GetAphelionDistance(c.e, c.a);
 
 			c.sortkey = CometManager.GetSortkey(c.id, c.fragment);
-			c.idKey = CometManager.GetIdKey(c.id, c.fragment);
 
 			return c;
 		}
@@ -469,7 +468,6 @@ namespace Comets.Core.Managers
 			c.Q = CometManager.GetAphelionDistance(c.e, c.a);
 
 			c.sortkey = CometManager.GetSortkey(c.id, c.fragment);
-			c.idKey = CometManager.GetIdKey(c.id);
 
 			return c;
 		}
@@ -521,7 +519,6 @@ namespace Comets.Core.Managers
 			c.Q = CometManager.GetAphelionDistance(c.e, c.a);
 
 			c.sortkey = CometManager.GetSortkey(c.id, c.fragment);
-			c.idKey = CometManager.GetIdKey(c.id);
 
 			return c;
 		}
@@ -656,7 +653,6 @@ namespace Comets.Core.Managers
 			c.Q = CometManager.GetAphelionDistance(c.e, c.a);
 
 			c.sortkey = CometManager.GetSortkey(c.id, c.fragment);
-			c.idKey = CometManager.GetIdKey(c.id);
 
 			return c;
 		}
@@ -712,7 +708,6 @@ namespace Comets.Core.Managers
 			c.Q = CometManager.GetAphelionDistance(c.e, c.a);
 
 			c.sortkey = CometManager.GetSortkey(c.id, c.fragment);
-			c.idKey = CometManager.GetIdKey(c.id);
 
 			return c;
 		}
@@ -782,7 +777,6 @@ namespace Comets.Core.Managers
 			c.Q = CometManager.GetAphelionDistance(c.e, c.a);
 
 			c.sortkey = CometManager.GetSortkey(c.id, c.fragment);
-			c.idKey = CometManager.GetIdKey(c.id);
 
 			return c;
 		}
@@ -837,7 +831,6 @@ namespace Comets.Core.Managers
 			c.Q = CometManager.GetAphelionDistance(c.e, c.a);
 
 			c.sortkey = CometManager.GetSortkey(c.id, c.fragment);
-			c.idKey = CometManager.GetIdKey(c.id);
 
 			return c;
 		}
@@ -896,7 +889,6 @@ namespace Comets.Core.Managers
 			c.Q = CometManager.GetAphelionDistance(c.e, c.a);
 
 			c.sortkey = CometManager.GetSortkey(c.id, c.fragment);
-			c.idKey = CometManager.GetIdKey(c.id);
 
 			return c;
 		}
@@ -955,7 +947,6 @@ namespace Comets.Core.Managers
 			c.Q = CometManager.GetAphelionDistance(c.e, c.a);
 
 			c.sortkey = CometManager.GetSortkey(c.id, c.fragment);
-			c.idKey = CometManager.GetIdKey(c.id);
 
 			return c;
 		}
@@ -1029,7 +1020,6 @@ namespace Comets.Core.Managers
 			c.Q = CometManager.GetAphelionDistance(c.e, c.a);
 
 			c.sortkey = CometManager.GetSortkey(c.id, c.fragment);
-			c.idKey = CometManager.GetIdKey(c.id);
 
 			return c;
 		}
@@ -1087,7 +1077,6 @@ namespace Comets.Core.Managers
 			c.Q = CometManager.GetAphelionDistance(c.e, c.a);
 
 			c.sortkey = CometManager.GetSortkey(c.id, c.fragment);
-			c.idKey = CometManager.GetIdKey(c.id);
 
 			return c;
 		}
@@ -1155,7 +1144,6 @@ namespace Comets.Core.Managers
 			c.Q = CometManager.GetAphelionDistance(c.e, c.a);
 
 			c.sortkey = CometManager.GetSortkey(c.id, c.fragment);
-			c.idKey = CometManager.GetIdKey(c.id);
 
 			return c;
 		}
@@ -1210,7 +1198,6 @@ namespace Comets.Core.Managers
 			c.Q = CometManager.GetAphelionDistance(c.e, c.a);
 
 			c.sortkey = CometManager.GetSortkey(c.id, c.fragment);
-			c.idKey = CometManager.GetIdKey(c.id);
 
 			return c;
 		}
@@ -1268,7 +1255,6 @@ namespace Comets.Core.Managers
 			c.Q = CometManager.GetAphelionDistance(c.e, c.a);
 
 			c.sortkey = CometManager.GetSortkey(c.id, c.fragment);
-			c.idKey = CometManager.GetIdKey(c.id);
 
 			return c;
 		}
@@ -1335,9 +1321,8 @@ namespace Comets.Core.Managers
 			c.n = CometManager.GetMeanMotion(c.e, c.P);
 			c.Q = CometManager.GetAphelionDistance(c.e, c.a);
 
-			//voyager nema id
-			//c.sortkey = CometManager.GetSortkey(c.id);
-			//c.idKey = CometManager.GetIdKey(c.id);
+			// voyager has no id
+			c.sortkey = string.Empty; // CometManager.GetSortkey(c.id);
 
 			return c;
 		}
@@ -1391,7 +1376,6 @@ namespace Comets.Core.Managers
 			c.Q = CometManager.GetAphelionDistance(c.e, c.a);
 
 			c.sortkey = CometManager.GetSortkey(c.id, c.fragment);
-			c.idKey = CometManager.GetIdKey(c.id);
 
 			return c;
 		}
@@ -1461,7 +1445,6 @@ namespace Comets.Core.Managers
 			c.Q = CometManager.GetAphelionDistance(c.e, c.a);
 
 			c.sortkey = CometManager.GetSortkey(c.id, c.fragment);
-			c.idKey = CometManager.GetIdKey(c.id);
 
 			return c;
 		}
@@ -1520,7 +1503,6 @@ namespace Comets.Core.Managers
 			c.Q = CometManager.GetAphelionDistance(c.e, c.a);
 
 			c.sortkey = CometManager.GetSortkey(c.id, c.fragment);
-			c.idKey = CometManager.GetIdKey(c.id);
 
 			return c;
 		}

--- a/src/Comets.OrbitViewer/OrbitViewer/Comet.cs
+++ b/src/Comets.OrbitViewer/OrbitViewer/Comet.cs
@@ -81,11 +81,6 @@ namespace Comets.OrbitViewer
 		public Matrix VectorConstant { get; private set; }
 
 		/// <summary>
-		/// SortKey
-		/// </summary>
-		public double SortKey { get; private set; }
-
-		/// <summary>
 		/// Comet location on Panel
 		/// </summary>
 		public Point PanelLocation { get; set; }
@@ -120,7 +115,6 @@ namespace Comets.OrbitViewer
 			this.g = comet.g;
 			this.k = comet.k;
 			this.Equinox = 2000.0;
-			this.SortKey = comet.sortkey;
 
 			int eqYear = (int)Math.Floor(this.Equinox);
 			double eqM = (this.Equinox - (double)eqYear) * 12.0;


### PR DESCRIPTION
**Change sortkey logic**

remove idKey  
change sortkey double to string  
employ more robust solution  

some examples, expanded for clarity:

```
1P            >  0 0001 000 000 00 00  ; numbered periodic comets with leading '0'
3D-A          >  0 0003 000 000 0A 00
5D-B1         >  0 0005 000 000 0B 01
240P          >  0 0240 000 000 00 00
C/-146 P1     >  1 9854 00P 001 00 00  ; negative years with leading '1'
C/-43 K1      >  1 9957 00K 001 00 00
C/240 V1      >  2 0240 00V 001 00 00  ; positive years with leading '2'; not the same as 240 above
C/2000 A1-B2  >  2 2000 00A 001 0B 02
1I            >  3 0001 000 000 00 00  ; interstellar objects moved to the end with leading '3'
```